### PR TITLE
feat: Add 'Add to Calendar' functionality

### DIFF
--- a/src/main/java/io/github/kurasey/wedding_invitation/controller/InvitationPageController.java
+++ b/src/main/java/io/github/kurasey/wedding_invitation/controller/InvitationPageController.java
@@ -5,12 +5,19 @@ import io.github.kurasey.wedding_invitation.exception.NotFoundFamily;
 import io.github.kurasey.wedding_invitation.model.Beverage;
 import io.github.kurasey.wedding_invitation.model.Family;
 import io.github.kurasey.wedding_invitation.service.FamilyService;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Controller
@@ -40,5 +47,35 @@ public class InvitationPageController {
                         .map(b -> Map.of("id", b.name(), "displayName", b.getName()))
                         .collect(Collectors.toList()));
         return "invitationPage";
+    }
+
+    @GetMapping("/event.ics")
+    public ResponseEntity<String> downloadIcsFile() {
+        ZonedDateTime eventStart = parametersHolder.getEventDateTime();
+        ZonedDateTime eventEnd = eventStart.plusDays(1).withHour(0).withMinute(0).withSecond(0);
+        String eventSummary = "Свадьба " + parametersHolder.getGroomName() + " и " + parametersHolder.getBrideName();
+        String eventLocation = parametersHolder.getVenueName() + ", " + parametersHolder.getVenueAddress();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'").withZone(ZoneOffset.UTC);
+
+        String icsContent = String.join("\r\n",
+                "BEGIN:VCALENDAR",
+                "VERSION:2.0",
+                "PRODID:-//dya-wedding.duckdns.org",
+                "BEGIN:VEVENT",
+                "UID:" + UUID.randomUUID(),
+                "DTSTAMP:" + formatter.format(ZonedDateTime.now()),
+                "DTSTART:" + formatter.format(eventStart),
+                "DTEND:" + formatter.format(eventEnd),
+                "SUMMARY:" + eventSummary,
+                "LOCATION:" + eventLocation,
+                "DESCRIPTION:" + "Не забудьте подтвердить свое присутствие!",
+                "END:VEVENT",
+                "END:VCALENDAR"
+        );
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.CONTENT_TYPE, "text/calendar; charset=utf-8");
+        headers.add(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"wedding_event.ics\"");
+        return new ResponseEntity<>(icsContent, headers, HttpStatus.OK);
+
     }
 }

--- a/src/main/resources/static/js/heart-script.js
+++ b/src/main/resources/static/js/heart-script.js
@@ -42,6 +42,9 @@ function generateWeddingCalendar(targetElement, year, monthIndex, highlightDay) 
             }
             html += `<div class="${cellClasses}" data-day="${day}">${dayContent}</div>`;
         }
+       const calendarLinkHref = `${window.location.pathname}/event.ics`;
+       html += `<a href="${calendarLinkHref}" class="calendar-footer-link" download="wedding_event.ics">Добавить в календарь</a>`;
+
         targetElement.innerHTML = html;
     }
 

--- a/src/main/resources/static/styles/calendar-style.css
+++ b/src/main/resources/static/styles/calendar-style.css
@@ -115,3 +115,28 @@
         transform: scale(1.3);
     }
 }
+
+
+
+.calendar-footer-link {
+    grid-column: 1 / -1;
+
+    display: block;
+    text-align: center;
+    padding: 12px 0;
+    margin-top: 10px;
+    background-color: transparent;
+
+    color: #a07070;
+    font-size: 1em;
+    font-family: 'Georgia', serif;
+    text-decoration: none;
+
+    /* Эффекты */
+    transition: background-color 0.3s, color 0.3s;
+}
+
+.calendar-footer-link:hover {
+    background-color: #fff9f9;
+    color: #8c5d5d;
+}


### PR DESCRIPTION
Implements the ability for guests to download an .ics file for the event.

- A new endpoint `/{personalLink}/event.ics` is created in `InvitationPageController` to dynamically generate the iCalendar file based on event details.
- The calendar generation script (`heart-script.js`) now appends an "Add to Calendar" link as a footer within the calendar widget itself.
- New CSS styles in `calendar-style.css` ensure the link is seamlessly integrated into the widget's design, spanning the full width of the grid.